### PR TITLE
Add git-based deployment

### DIFF
--- a/extra/deploy.sh
+++ b/extra/deploy.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+# Local folder with static site contents
+OUTPUT_DIR=_site/
+# Remote user and host to connect to
+PLCLUB_ACCOUNT=plclub@eniac
+# Location of folder relative to remote user's home directory
+# This variable may also need to be set in ./deploy_remote.sh
+REMOTE_FOLDER=website_repo_test
+# Script to run on remote e.g. to make a tar backup before syncing
+# this should be relative to the top-level repo folder
+REMOTE_SCRIPT=./extra/deploy_remote.sh
+
+# Run the remote helper script
+ssh plclub@eniac "bash -s" < $REMOTE_SCRIPT
+
+# Synchronize our local folder to the remote
+rsync -vr $OUTPUT_DIR plclub@eniac:$REMOTE_FOLDER

--- a/extra/deploy.sh
+++ b/extra/deploy.sh
@@ -5,13 +5,13 @@ OUTPUT_DIR=_site/
 PLCLUB_ACCOUNT=plclub@eniac
 # Location of folder relative to remote user's home directory
 # This variable may also need to be set in ./deploy_remote.sh
-REMOTE_FOLDER=website_repo_test
-# Script to run on remote e.g. to make a tar backup before syncing
+REMOTE_FOLDER=html/
+# Script to run on remote e.g. to make a backup before syncing
 # this should be relative to the top-level repo folder
 REMOTE_SCRIPT=./extra/deploy_remote.sh
 
-# Run the remote helper script
-ssh plclub@eniac "bash -s" < $REMOTE_SCRIPT
-
 # Synchronize our local folder to the remote
-rsync -vr $OUTPUT_DIR plclub@eniac:$REMOTE_FOLDER
+rsync -vr $OUTPUT_DIR $PLCLUB_ACCOUNT:$REMOTE_FOLDER
+
+# Run the remote helper script
+ssh $PLCLUB_ACCOUNT "bash -s" < $REMOTE_SCRIPT

--- a/extra/deploy_remote.sh
+++ b/extra/deploy_remote.sh
@@ -1,0 +1,4 @@
+# This script is run on the remote (plclub@eniac)
+# it is launched by ./deploy.sh
+REMOTE_FOLDER=website_repo_test
+tar -zc -f $REMOTE_FOLDER-$(date '+%F').tar.gz $REMOTE_FOLDER

--- a/extra/deploy_remote.sh
+++ b/extra/deploy_remote.sh
@@ -1,4 +1,6 @@
 # This script is run on the remote (plclub@eniac)
 # it is launched by ./deploy.sh
-REMOTE_FOLDER=website_repo_test
-tar -zc -f $REMOTE_FOLDER-$(date '+%F').tar.gz $REMOTE_FOLDER
+REMOTE_FOLDER=html/
+cd $REMOTE_FOLDER
+git add .
+git commit -m "Automated commit"

--- a/lib/PLClub.hs
+++ b/lib/PLClub.hs
@@ -20,9 +20,7 @@ thenRoute = composeRoutes
 
 config :: Configuration
 config = defaultConfiguration
-  { deployCommand =
-      "ssh plclub@eniac \"tar -zc -f html-$(date '+%F').tar.gz html\";\
-      \ rsync -vr _site/ plclub@eniac:html"
+  { deployCommand = "./extra/deploy.sh"
   }
   
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This revamps the deployment system to use git.

The old system did the following:
1. ssh into eniac, make a .tar snapshot of the html/ directory (for caution)
2. rsync _site/ to eniac

The new system does this (html is now a git repository):
1. rsync _site/ to eniac
2. ssh into eniac, commit the working directory into the repo there

This gives free rollbacks, file efficiency, time stamping, and various `git log` features. I found this was significantly easier than using an ephemeral `release/` branch similar to what is described here: https://jaspervdj.be/hakyll/tutorials/github-pages-tutorial.html

(The latter method made for very long `git push` times for compression reasons I couldn't fix, and was generally way more complicated due to the need to add eniac as a remote and deal with making an ephemeral branch.)